### PR TITLE
Globally expose operator<< to tinyformat

### DIFF
--- a/src/util/chaintype.h
+++ b/src/util/chaintype.h
@@ -17,6 +17,12 @@ enum class ChainType {
 
 std::string ChainTypeToString(ChainType chain);
 
+// Globally expose operator<< to tinyformat
+inline std::ostream& operator<<(std::ostream& os, const ChainType& chain) {
+    os << ChainTypeToString(chain);
+    return os;
+}
+
 std::optional<ChainType> ChainTypeFromString(std::string_view chain);
 
 #endif // BITCOIN_UTIL_CHAINTYPE_H


### PR DESCRIPTION
Added operator<< overload for ChainType to enable formatted output for tinyformat. Otherwise compiling with the use of depends fails on Debian 11.